### PR TITLE
M.lock turf difference

### DIFF
--- a/modules/edit-modes/package.json
+++ b/modules/edit-modes/package.json
@@ -54,7 +54,7 @@
     "@turf/centroid": ">=4.0.0",
     "@turf/circle": ">=4.0.0",
     "@turf/destination": ">=4.0.0",
-    "@turf/difference": ">=4.0.0",
+    "@turf/difference": "6.0.1",
     "@turf/distance": ">=4.0.0",
     "@turf/ellipse": ">=4.0.0",
     "@turf/helpers": ">=4.0.0",

--- a/modules/layers/package.json
+++ b/modules/layers/package.json
@@ -55,7 +55,7 @@
     "@turf/centroid": ">=4.0.0",
     "@turf/circle": ">=4.0.0",
     "@turf/destination": ">=4.0.0",
-    "@turf/difference": ">=4.0.0",
+    "@turf/difference": "6.0.1",
     "@turf/distance": ">=4.0.0",
     "@turf/ellipse": ">=4.0.0",
     "@turf/helpers": ">=4.0.0",

--- a/modules/main/package.json
+++ b/modules/main/package.json
@@ -56,7 +56,7 @@
     "@turf/centroid": ">=4.0.0",
     "@turf/circle": ">=4.0.0",
     "@turf/destination": ">=4.0.0",
-    "@turf/difference": ">=4.0.0",
+    "@turf/difference": "6.0.1",
     "@turf/distance": ">=4.0.0",
     "@turf/ellipse": ">=4.0.0",
     "@turf/helpers": ">=4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,16 +1762,16 @@
     "@turf/helpers" "6.x"
     "@turf/invariant" "6.x"
 
-"@turf/difference@>=4.0.0":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.0.2.tgz#dd20c0e2301ba6c22019e38a36eea3975205a77f"
-  integrity sha512-WtXkvFgOyHqsG3xtYG/m5Su+gkvyCUTbdW0XOuc3Ha2u9UeeBSGwEzTc2y9THDLDhHqR+DlTl1MMEBihXcy3fg==
+"@turf/difference@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@turf/difference/-/difference-6.0.1.tgz#a5ee3433eddb7d707cac227adf0d43ab0d651682"
+  integrity sha512-lkhJjNfPeLARQm232A851vVhrUvX3gdvTft5QlqkUlr7AzLpiT8PW14yEkU9xABxRh6PGv7T1UUVAeRgC7JxuA==
   dependencies:
     "@turf/area" "6.x"
     "@turf/helpers" "6.x"
     "@turf/invariant" "6.x"
     "@turf/meta" "6.x"
-    martinez-polygon-clipping "^0.4.3"
+    martinez-polygon-clipping "*"
 
 "@turf/distance@6.x", "@turf/distance@>=4.0.0":
   version "6.0.1"
@@ -6996,6 +6996,15 @@ mapbox-gl@^1.0.0:
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
 
+martinez-polygon-clipping@*:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.7.0.tgz#5ae979d4ba32c6425c8cdd422f14d54276350ab7"
+  integrity sha512-EBxKjlUqrVjzT1HRwJARaSwj66JZqEUl+JnqnrzHZLU4hd4XrCQWqShZx40264NR/pm5wIHRlNEaIrev44wvKA==
+  dependencies:
+    robust-predicates "^2.0.4"
+    splaytree "^0.1.4"
+    tinyqueue "^1.2.0"
+
 martinez-polygon-clipping@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/martinez-polygon-clipping/-/martinez-polygon-clipping-0.4.3.tgz#a3971ddf1da147104b5d0fbbf68f728bb62885c1"
@@ -8915,6 +8924,11 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^2.0.0"
     inherits "^2.0.1"
+
+robust-predicates@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/robust-predicates/-/robust-predicates-2.0.4.tgz#0a2367a93abd99676d075981707f29cfb402248b"
+  integrity sha512-l4NwboJM74Ilm4VKfbAtFeGq7aEjWL+5kVFcmgFA2MrdnQWx9iE/tUGvxY5HyMI7o/WpSIUFLbC5fbeaHgSCYg==
 
 rsvp@^4.8.4:
   version "4.8.4"


### PR DESCRIPTION
latest @turf/difference 6.0.2 doesn't work with webpack https://github.com/Turfjs/turf/issues/1383#issuecomment-434486339 so we're locking to 6.0.1
unblocks https://github.com/zumper/web-zumper/pull/236